### PR TITLE
feat: add landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,80 +1,175 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>SidebarAIchat.com</title>
-  <style>
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
-      background-color: #ffffff;
-      color: #24292f;
-      margin: 0;
-      padding: 0;
-      line-height: 1.6;
-      display: flex;
-      flex-direction: column;
-      min-height: 100vh;
-    }
-    header {
-      background-color: #f6f8fa;
-      border-bottom: 1px solid #d0d7de;
-      padding: 1.5rem;
-      text-align: center;
-    }
-    header h1 {
-      margin: 0;
-      font-size: 2rem;
-      font-weight: 600;
-    }
-    main {
-      flex: 1;
-      max-width: 720px;
-      margin: 2rem auto;
-      padding: 0 1rem;
-    }
-    h2 {
-      font-size: 1.5rem;
-      margin-top: 1.5rem;
-    }
-    p {
-      margin: 1rem 0;
-    }
-    .status {
-      background: #fff8c5;
-      border: 1px solid #d4a72c;
-      color: #633c01;
-      padding: 0.75rem 1rem;
-      border-radius: 6px;
-      margin-top: 1.5rem;
-      font-weight: 500;
-    }
-    footer {
-      text-align: center;
-      padding: 1rem;
-      font-size: 0.9rem;
-      color: #57606a;
-      border-top: 1px solid #d0d7de;
-    }
-  </style>
-</head>
-<body>
-  <header>
-    <h1>SidebarAIchat.com</h1>
-  </header>
-  <main>
-    <h2>About</h2>
-    <p><strong>SidebarAIchat</strong> is a Chrome sidebar extension that brings AI assistance directly into your browsing experience.</p>
-    
-    <h2>Status</h2>
-    <p class="status">🚧 This project is still in development. Stay tuned for updates!</p>
-  </main>
-  <footer>
-    © <span id="year"></span> SidebarAIchat.com
-  </footer>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SidebarAIchat.com</title>
+    <style>
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial,
+          sans-serif;
+        background-color: #ffffff;
+        color: #24292f;
+        margin: 0;
+        padding: 0;
+        line-height: 1.6;
+        display: flex;
+        flex-direction: column;
+        min-height: 100vh;
+      }
+      header {
+        background-color: #f6f8fa;
+        border-bottom: 1px solid #d0d7de;
+        padding: 1.5rem;
+        text-align: center;
+      }
+      header h1 {
+        margin: 0;
+        font-size: 2rem;
+        font-weight: 600;
+      }
+      main {
+        flex: 1;
+        max-width: 720px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+      }
+      h2 {
+        font-size: 1.5rem;
+        margin-top: 1.5rem;
+      }
+      p {
+        margin: 1rem 0;
+      }
+      .hero {
+        text-align: center;
+      }
+      .feature {
+        margin-top: 2rem;
+      }
+      .placeholder {
+        width: 100%;
+        height: 240px;
+        background-color: #e5e7eb;
+        border: 1px dashed #9ca3af;
+        border-radius: 6px;
+        display: block;
+      }
+      .status {
+        background: #fff8c5;
+        border: 1px solid #d4a72c;
+        color: #633c01;
+        padding: 0.75rem 1rem;
+        border-radius: 6px;
+        margin-top: 2rem;
+        font-weight: 500;
+        text-align: center;
+      }
+      footer {
+        text-align: center;
+        padding: 1rem;
+        font-size: 0.9rem;
+        color: #57606a;
+        border-top: 1px solid #d0d7de;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>SidebarAIchat.com</h1>
+    </header>
+    <main>
+      <section class="hero">
+        <h2>Bring any AI model into your browser</h2>
+        <p>
+          No subscriptions. Just plug in your own API key and start chatting.
+        </p>
+        <img src="about:blank" alt="Hero image" class="placeholder" />
+      </section>
 
-  <script>
-    document.getElementById("year").textContent = new Date().getFullYear();
-  </script>
-</body>
+      <section class="feature">
+        <h2>Selecting a Model</h2>
+        <p>
+          Pick from any AI model you've added to the sidebar. You're never
+          locked into one provider—use the right tool for the job.
+        </p>
+        <img
+          src="about:blank"
+          alt="Model selection screenshot"
+          class="placeholder"
+        />
+      </section>
+
+      <section class="feature">
+        <h2>Working With Files</h2>
+        <p>
+          Upload text-based files like TXT, CSV, JSON or XML directly into the
+          chat. PDFs and images are on the roadmap.
+        </p>
+        <img
+          src="about:blank"
+          alt="File upload screenshot"
+          class="placeholder"
+        />
+      </section>
+
+      <section class="feature">
+        <h2>Managing Chats</h2>
+        <p>
+          Every conversation is saved. Switching chats while a response streams
+          is a known issue—expect real-time updates soon.
+        </p>
+        <img
+          src="about:blank"
+          alt="Chat management screenshot"
+          class="placeholder"
+        />
+      </section>
+
+      <section class="feature">
+        <h2>Messaging and Output</h2>
+        <p>
+          Send messages normally and enjoy highlighted code. LaTeX support isn't
+          here yet but it's in the plans.
+        </p>
+        <img src="about:blank" alt="Messaging screenshot" class="placeholder" />
+      </section>
+
+      <section class="feature">
+        <h2>Assistants and Instructions</h2>
+        <p>
+          Add multiple assistants for different providers and assign custom
+          instructions per chat for quicker prompts.
+        </p>
+        <img
+          src="about:blank"
+          alt="Assistants screenshot"
+          class="placeholder"
+        />
+      </section>
+
+      <section class="feature">
+        <h2>Chat Configurations</h2>
+        <p>
+          Bundle models, assistants and instructions into reusable
+          configurations. Swap setups with a single click.
+        </p>
+        <img
+          src="about:blank"
+          alt="Chat configuration screenshot"
+          class="placeholder"
+        />
+      </section>
+
+      <section class="status">
+        🚧 This project is still in development. Stay tuned for updates!
+      </section>
+    </main>
+    <footer>© <span id="year"></span> SidebarAIchat.com</footer>
+
+    <script>
+      document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- replace minimal page with full landing layout for SidebarAIchat
- describe key features, including model selection and chat configurations
- add image placeholders for future screenshots and note project status

## Testing
- `npx --yes prettier index.html --check`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68beeddd5630832dbe063a9c95635d27