### PR TITLE
style: refresh design and theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,14 +3,15 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
     <title>SidebarAIchat.com</title>
     <style>
       :root {
-        --bg: #ffffff;
-        --text: #1f2937;
-        --border: #e5e7eb;
+        --bg: #f7f7f8;
+        --text: #343541;
+        --border: #d1d5db;
         --muted: #6b7280;
-        --header-bg: #f9fafb;
+        --header-bg: #ffffff;
         --placeholder-bg: #e5e7eb;
         --placeholder-border: #9ca3af;
         --status-bg: #fef3c7;
@@ -18,6 +19,7 @@
         --status-text: #92400e;
       }
 
+      body {
         background-color: var(--bg);
         color: var(--text);
         margin: 0;
@@ -26,22 +28,24 @@
         display: flex;
         flex-direction: column;
         min-height: 100vh;
-        transition:
-          background-color 0.3s,
-          color 0.3s;
+        transition: background-color 0.3s, color 0.3s;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+          Roboto, sans-serif;
       }
-      .dark {
-        --bg: #111827;
-        --text: #f3f4f6;
-        --border: #374151;
+
+      body.dark {
+        --bg: #343541;
+        --text: #ececf1;
+        --border: #444654;
         --muted: #9ca3af;
-        --header-bg: #1f2937;
-        --placeholder-bg: #374151;
-        --placeholder-border: #4b5563;
+        --header-bg: #202123;
+        --placeholder-bg: #40414f;
+        --placeholder-border: #565869;
         --status-bg: #78350f;
         --status-border: #f59e0b;
         --status-text: #fef3c7;
       }
+
       header {
         background-color: var(--header-bg);
         border-bottom: 1px solid var(--border);
@@ -50,42 +54,58 @@
         align-items: center;
         justify-content: space-between;
       }
+
       header h1 {
         margin: 0;
         font-size: 2rem;
         font-weight: 600;
       }
+
       #theme-toggle {
         background: none;
         border: none;
-        font-size: 1.25rem;
         cursor: pointer;
         color: var(--text);
+        width: 32px;
+        height: 32px;
       }
+
+      #theme-toggle svg {
+        width: 100%;
+        height: 100%;
+        stroke: currentColor;
+        fill: none;
+      }
+
       main {
         flex: 1;
         max-width: 720px;
         margin: 2rem auto;
         padding: 0 1rem;
       }
+
       h2 {
         font-size: 1.5rem;
         margin-top: 1.5rem;
       }
+
       p {
         margin: 1rem 0;
         color: var(--muted);
       }
+
       .hero {
         text-align: center;
         margin-top: 1rem;
       }
+
       .feature {
         margin-top: 2rem;
         padding: 1.5rem;
         border: 1px solid var(--border);
         border-radius: 8px;
       }
+
       .placeholder {
         width: 100%;
         height: 240px;
@@ -94,6 +114,7 @@
         border-radius: 6px;
         display: block;
       }
+
       .status {
         background: var(--status-bg);
         border: 1px solid var(--status-border);
@@ -104,6 +125,7 @@
         font-weight: 500;
         text-align: center;
       }
+
       footer {
         text-align: center;
         padding: 1rem;
@@ -210,23 +232,34 @@
     <script>
       const year = document.getElementById("year");
       year.textContent = new Date().getFullYear();
+
       const toggle = document.getElementById("theme-toggle");
+      const sunIcon =
+        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><path d="M12 1v2m0 18v2m11-11h-2M3 12H1m17.657-7.657l-1.414 1.414M6.343 17.657l-1.414 1.414m0-12.728l1.414 1.414m12.728 12.728l1.414-1.414"/></svg>';
+      const moonIcon =
+        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+
       function applyTheme(dark) {
         document.body.classList.toggle("dark", dark);
-        toggle.textContent = dark ? "☀️" : "🌙";
+        toggle.innerHTML = dark ? sunIcon : moonIcon;
+        toggle.setAttribute(
+          "aria-label",
+          dark ? "Switch to light mode" : "Switch to dark mode",
+        );
       }
+
       const stored = localStorage.getItem("theme");
       applyTheme(
         stored
           ? stored === "dark"
           : window.matchMedia("(prefers-color-scheme: dark)").matches,
       );
+
       toggle.addEventListener("click", () => {
         const isDark = !document.body.classList.contains("dark");
         applyTheme(isDark);
         localStorage.setItem("theme", isDark ? "dark" : "light");
       });
-
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- restyle landing page with ChatGPT-like light/dark palette
- replace emoji theme toggle with monochrome SVG icons
- fix theme toggling by applying styles to the body element

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68befecf937c832db3737e6730feceab