### PR TITLE
Link site title to homepage

### DIFF
--- a/docs/faq.html
+++ b/docs/faq.html
@@ -97,7 +97,7 @@
   </head>
   <body>
     <header>
-      <h1>SidebarAIchat.com</h1>
+      <h1><a href="/">Sidebar AI Chat</a></h1>
       <nav><a href="/docs/">Documentation</a></nav>
       <button id="theme-toggle" aria-label="Toggle theme"></button>
     </header>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -97,7 +97,7 @@
   </head>
   <body>
     <header>
-      <h1>SidebarAIchat.com</h1>
+      <h1><a href="/">Sidebar AI Chat</a></h1>
       <nav><a href="/docs/">Documentation</a></nav>
       <button id="theme-toggle" aria-label="Toggle theme"></button>
     </header>

--- a/docs/index.html
+++ b/docs/index.html
@@ -97,7 +97,7 @@
   </head>
   <body>
     <header>
-      <h1>SidebarAIchat.com</h1>
+      <h1><a href="/">Sidebar AI Chat</a></h1>
       <nav><a href="/docs/">Documentation</a></nav>
       <button id="theme-toggle" aria-label="Toggle theme"></button>
     </header>

--- a/docs/setup-instructions.html
+++ b/docs/setup-instructions.html
@@ -97,7 +97,7 @@
   </head>
   <body>
     <header>
-      <h1>SidebarAIchat.com</h1>
+      <h1><a href="/">Sidebar AI Chat</a></h1>
       <nav><a href="/docs/">Documentation</a></nav>
       <button id="theme-toggle" aria-label="Toggle theme"></button>
     </header>

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -97,7 +97,7 @@
   </head>
   <body>
     <header>
-      <h1>SidebarAIchat.com</h1>
+      <h1><a href="/">Sidebar AI Chat</a></h1>
       <nav><a href="/docs/">Documentation</a></nav>
       <button id="theme-toggle" aria-label="Toggle theme"></button>
     </header>

--- a/index.html
+++ b/index.html
@@ -153,7 +153,7 @@
   </head>
   <body>
     <header>
-      <h1>SidebarAIchat.com</h1>
+      <h1><a href="/">Sidebar AI Chat</a></h1>
       <nav><a href="/docs/">Documentation</a></nav>
       <button id="theme-toggle" aria-label="Toggle dark mode"></button>
     </header>


### PR DESCRIPTION
## Summary
- Replace `SidebarAIchat.com` header text with linked "Sidebar AI Chat" across pages.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0d4b3dcc832dbef7a390c523739b