### PR TITLE
Align navigation layout and rename docs link

### DIFF
--- a/docs/faq.html
+++ b/docs/faq.html
@@ -40,7 +40,7 @@
         padding: 1.5rem;
         display: flex;
         align-items: center;
-        justify-content: space-between;
+        justify-content: flex-start;
       }
 
       header h1 {
@@ -49,8 +49,12 @@
         font-weight: 600;
       }
 
+      header nav {
+        margin-left: auto;
+      }
+
       header nav a {
-        margin-left: 1rem;
+        margin-right: 1rem;
         color: var(--text);
         text-decoration: none;
       }
@@ -98,7 +102,7 @@
   <body>
     <header>
       <h1><a href="/">Sidebar AI Chat</a></h1>
-      <nav><a href="/docs/">Documentation</a></nav>
+      <nav><a href="/docs/">Docs</a></nav>
       <button id="theme-toggle" aria-label="Toggle theme"></button>
     </header>
     <main>
@@ -108,7 +112,7 @@
       <p><strong>Is there a cost to use SidebarAI Chat?</strong><br />The extension is free. You only pay for usage from your API provider.</p>
     </main>
     <footer>
-      © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Documentation</a>
+      © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Docs</a>
     </footer>
     <script>
       const year = document.getElementById("year");

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -40,7 +40,7 @@
         padding: 1.5rem;
         display: flex;
         align-items: center;
-        justify-content: space-between;
+        justify-content: flex-start;
       }
 
       header h1 {
@@ -49,8 +49,12 @@
         font-weight: 600;
       }
 
+      header nav {
+        margin-left: auto;
+      }
+
       header nav a {
-        margin-left: 1rem;
+        margin-right: 1rem;
         color: var(--text);
         text-decoration: none;
       }
@@ -98,7 +102,7 @@
   <body>
     <header>
       <h1><a href="/">Sidebar AI Chat</a></h1>
-      <nav><a href="/docs/">Documentation</a></nav>
+      <nav><a href="/docs/">Docs</a></nav>
       <button id="theme-toggle" aria-label="Toggle theme"></button>
     </header>
     <main>
@@ -110,7 +114,7 @@
       <p>You're ready to begin chatting with your chosen model.</p>
     </main>
     <footer>
-      © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Documentation</a>
+      © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Docs</a>
     </footer>
     <script>
       const year = document.getElementById("year");

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
-    <title>Documentation - SidebarAIchat.com</title>
+    <title>Docs - SidebarAIchat.com</title>
     <style>
       :root {
         --bg: #f7f7f8;
@@ -40,7 +40,7 @@
         padding: 1.5rem;
         display: flex;
         align-items: center;
-        justify-content: space-between;
+        justify-content: flex-start;
       }
 
       header h1 {
@@ -49,8 +49,12 @@
         font-weight: 600;
       }
 
+      header nav {
+        margin-left: auto;
+      }
+
       header nav a {
-        margin-left: 1rem;
+        margin-right: 1rem;
         color: var(--text);
         text-decoration: none;
       }
@@ -98,11 +102,11 @@
   <body>
     <header>
       <h1><a href="/">Sidebar AI Chat</a></h1>
-      <nav><a href="/docs/">Documentation</a></nav>
+      <nav><a href="/docs/">Docs</a></nav>
       <button id="theme-toggle" aria-label="Toggle theme"></button>
     </header>
     <main>
-      <h2>Documentation</h2>
+      <h2>Docs</h2>
       <ul>
         <li><a href="getting-started.html">Getting Started</a></li>
         <li><a href="setup-instructions.html">Setup Instructions</a></li>
@@ -111,7 +115,7 @@
       </ul>
     </main>
     <footer>
-      © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Documentation</a>
+      © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Docs</a>
     </footer>
     <script>
       const year = document.getElementById("year");

--- a/docs/setup-instructions.html
+++ b/docs/setup-instructions.html
@@ -40,7 +40,7 @@
         padding: 1.5rem;
         display: flex;
         align-items: center;
-        justify-content: space-between;
+        justify-content: flex-start;
       }
 
       header h1 {
@@ -49,8 +49,12 @@
         font-weight: 600;
       }
 
+      header nav {
+        margin-left: auto;
+      }
+
       header nav a {
-        margin-left: 1rem;
+        margin-right: 1rem;
         color: var(--text);
         text-decoration: none;
       }
@@ -98,7 +102,7 @@
   <body>
     <header>
       <h1><a href="/">Sidebar AI Chat</a></h1>
-      <nav><a href="/docs/">Documentation</a></nav>
+      <nav><a href="/docs/">Docs</a></nav>
       <button id="theme-toggle" aria-label="Toggle theme"></button>
     </header>
     <main>
@@ -112,7 +116,7 @@
       <p>Open the sidebar and start a test chat. If the model responds, your setup is complete.</p>
     </main>
     <footer>
-      © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Documentation</a>
+      © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Docs</a>
     </footer>
     <script>
       const year = document.getElementById("year");

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -40,7 +40,7 @@
         padding: 1.5rem;
         display: flex;
         align-items: center;
-        justify-content: space-between;
+        justify-content: flex-start;
       }
 
       header h1 {
@@ -49,8 +49,12 @@
         font-weight: 600;
       }
 
+      header nav {
+        margin-left: auto;
+      }
+
       header nav a {
-        margin-left: 1rem;
+        margin-right: 1rem;
         color: var(--text);
         text-decoration: none;
       }
@@ -98,7 +102,7 @@
   <body>
     <header>
       <h1><a href="/">Sidebar AI Chat</a></h1>
-      <nav><a href="/docs/">Documentation</a></nav>
+      <nav><a href="/docs/">Docs</a></nav>
       <button id="theme-toggle" aria-label="Toggle theme"></button>
     </header>
     <main>
@@ -113,7 +117,7 @@
       <p>If issues persist, reach out on the project repository with details.</p>
     </main>
     <footer>
-      © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Documentation</a>
+      © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Docs</a>
     </footer>
     <script>
       const year = document.getElementById("year");

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
         padding: 1.5rem;
         display: flex;
         align-items: center;
-        justify-content: space-between;
+        justify-content: flex-start;
       }
 
       header h1 {
@@ -71,8 +71,12 @@
         font-weight: 600;
       }
 
+      header nav {
+        margin-left: auto;
+      }
+
       header nav a {
-        margin-left: 1rem;
+        margin-right: 1rem;
         color: var(--text);
         text-decoration: none;
       }
@@ -154,7 +158,7 @@
   <body>
     <header>
       <h1><a href="/">Sidebar AI Chat</a></h1>
-      <nav><a href="/docs/">Documentation</a></nav>
+      <nav><a href="/docs/">Docs</a></nav>
       <button id="theme-toggle" aria-label="Toggle dark mode"></button>
     </header>
     <main>
@@ -244,7 +248,7 @@
         🚧 This project is still in development. Stay tuned for updates!
       </section>
     </main>
-    <footer>© <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Documentation</a></footer>
+    <footer>© <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Docs</a></footer>
 
     <script>
       const year = document.getElementById("year");


### PR DESCRIPTION
## Summary
- Push top navigation to the right for clearer layout
- Rename "Documentation" links and references to "Docs"

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0f1c4118832dafc8366a048794f9