### PR TITLE
Align navigation layout and rename docs link

### DIFF
--- a/docs/faq.html
+++ b/docs/faq.html
@@ -12,6 +12,7 @@
         --border: #d1d5db;
         --muted: #6b7280;
         --header-bg: #ffffff;
+        --nav-link-hover: #1f2937;
       }
 
       body {
@@ -32,6 +33,7 @@
         --border: #444654;
         --muted: #9ca3af;
         --header-bg: #202123;
+        --nav-link-hover: #d1d5db;
       }
 
       header {
@@ -40,7 +42,7 @@
         padding: 1.5rem;
         display: flex;
         align-items: center;
-        justify-content: space-between;
+        justify-content: flex-start;
       }
 
       header h1 {
@@ -49,10 +51,21 @@
         font-weight: 600;
       }
 
+      header nav {
+        margin-left: auto;
+      }
+
       header nav a {
-        margin-left: 1rem;
+        margin-right: 1rem;
         color: var(--text);
         text-decoration: none;
+        font-size: 1.125rem;
+        font-weight: 600;
+        transition: color 0.2s;
+      }
+
+      header nav a:hover {
+        color: var(--nav-link-hover);
       }
 
       #theme-toggle {
@@ -98,7 +111,7 @@
   <body>
     <header>
       <h1><a href="/">Sidebar AI Chat</a></h1>
-      <nav><a href="/docs/">Documentation</a></nav>
+      <nav><a href="/docs/">Docs</a></nav>
       <button id="theme-toggle" aria-label="Toggle theme"></button>
     </header>
     <main>
@@ -108,7 +121,7 @@
       <p><strong>Is there a cost to use SidebarAI Chat?</strong><br />The extension is free. You only pay for usage from your API provider.</p>
     </main>
     <footer>
-      © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Documentation</a>
+      © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Docs</a>
     </footer>
     <script>
       const year = document.getElementById("year");

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -12,6 +12,7 @@
         --border: #d1d5db;
         --muted: #6b7280;
         --header-bg: #ffffff;
+        --nav-link-hover: #1f2937;
       }
 
       body {
@@ -32,6 +33,7 @@
         --border: #444654;
         --muted: #9ca3af;
         --header-bg: #202123;
+        --nav-link-hover: #d1d5db;
       }
 
       header {
@@ -40,7 +42,7 @@
         padding: 1.5rem;
         display: flex;
         align-items: center;
-        justify-content: space-between;
+        justify-content: flex-start;
       }
 
       header h1 {
@@ -49,10 +51,21 @@
         font-weight: 600;
       }
 
+      header nav {
+        margin-left: auto;
+      }
+
       header nav a {
-        margin-left: 1rem;
+        margin-right: 1rem;
         color: var(--text);
         text-decoration: none;
+        font-size: 1.125rem;
+        font-weight: 600;
+        transition: color 0.2s;
+      }
+
+      header nav a:hover {
+        color: var(--nav-link-hover);
       }
 
       #theme-toggle {
@@ -98,7 +111,7 @@
   <body>
     <header>
       <h1><a href="/">Sidebar AI Chat</a></h1>
-      <nav><a href="/docs/">Documentation</a></nav>
+      <nav><a href="/docs/">Docs</a></nav>
       <button id="theme-toggle" aria-label="Toggle theme"></button>
     </header>
     <main>
@@ -110,7 +123,7 @@
       <p>You're ready to begin chatting with your chosen model.</p>
     </main>
     <footer>
-      © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Documentation</a>
+      © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Docs</a>
     </footer>
     <script>
       const year = document.getElementById("year");

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
-    <title>Documentation - SidebarAIchat.com</title>
+    <title>Docs - SidebarAIchat.com</title>
     <style>
       :root {
         --bg: #f7f7f8;
@@ -12,6 +12,7 @@
         --border: #d1d5db;
         --muted: #6b7280;
         --header-bg: #ffffff;
+        --nav-link-hover: #1f2937;
       }
 
       body {
@@ -32,6 +33,7 @@
         --border: #444654;
         --muted: #9ca3af;
         --header-bg: #202123;
+        --nav-link-hover: #d1d5db;
       }
 
       header {
@@ -40,7 +42,7 @@
         padding: 1.5rem;
         display: flex;
         align-items: center;
-        justify-content: space-between;
+        justify-content: flex-start;
       }
 
       header h1 {
@@ -49,10 +51,21 @@
         font-weight: 600;
       }
 
+      header nav {
+        margin-left: auto;
+      }
+
       header nav a {
-        margin-left: 1rem;
+        margin-right: 1rem;
         color: var(--text);
         text-decoration: none;
+        font-size: 1.125rem;
+        font-weight: 600;
+        transition: color 0.2s;
+      }
+
+      header nav a:hover {
+        color: var(--nav-link-hover);
       }
 
       #theme-toggle {
@@ -98,11 +111,11 @@
   <body>
     <header>
       <h1><a href="/">Sidebar AI Chat</a></h1>
-      <nav><a href="/docs/">Documentation</a></nav>
+      <nav><a href="/docs/">Docs</a></nav>
       <button id="theme-toggle" aria-label="Toggle theme"></button>
     </header>
     <main>
-      <h2>Documentation</h2>
+      <h2>Docs</h2>
       <ul>
         <li><a href="getting-started.html">Getting Started</a></li>
         <li><a href="setup-instructions.html">Setup Instructions</a></li>
@@ -111,7 +124,7 @@
       </ul>
     </main>
     <footer>
-      © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Documentation</a>
+      © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Docs</a>
     </footer>
     <script>
       const year = document.getElementById("year");

--- a/docs/setup-instructions.html
+++ b/docs/setup-instructions.html
@@ -12,6 +12,7 @@
         --border: #d1d5db;
         --muted: #6b7280;
         --header-bg: #ffffff;
+        --nav-link-hover: #1f2937;
       }
 
       body {
@@ -32,6 +33,7 @@
         --border: #444654;
         --muted: #9ca3af;
         --header-bg: #202123;
+        --nav-link-hover: #d1d5db;
       }
 
       header {
@@ -40,7 +42,7 @@
         padding: 1.5rem;
         display: flex;
         align-items: center;
-        justify-content: space-between;
+        justify-content: flex-start;
       }
 
       header h1 {
@@ -49,10 +51,21 @@
         font-weight: 600;
       }
 
+      header nav {
+        margin-left: auto;
+      }
+
       header nav a {
-        margin-left: 1rem;
+        margin-right: 1rem;
         color: var(--text);
         text-decoration: none;
+        font-size: 1.125rem;
+        font-weight: 600;
+        transition: color 0.2s;
+      }
+
+      header nav a:hover {
+        color: var(--nav-link-hover);
       }
 
       #theme-toggle {
@@ -98,7 +111,7 @@
   <body>
     <header>
       <h1><a href="/">Sidebar AI Chat</a></h1>
-      <nav><a href="/docs/">Documentation</a></nav>
+      <nav><a href="/docs/">Docs</a></nav>
       <button id="theme-toggle" aria-label="Toggle theme"></button>
     </header>
     <main>
@@ -112,7 +125,7 @@
       <p>Open the sidebar and start a test chat. If the model responds, your setup is complete.</p>
     </main>
     <footer>
-      © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Documentation</a>
+      © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Docs</a>
     </footer>
     <script>
       const year = document.getElementById("year");

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -12,6 +12,7 @@
         --border: #d1d5db;
         --muted: #6b7280;
         --header-bg: #ffffff;
+        --nav-link-hover: #1f2937;
       }
 
       body {
@@ -32,6 +33,7 @@
         --border: #444654;
         --muted: #9ca3af;
         --header-bg: #202123;
+        --nav-link-hover: #d1d5db;
       }
 
       header {
@@ -40,7 +42,7 @@
         padding: 1.5rem;
         display: flex;
         align-items: center;
-        justify-content: space-between;
+        justify-content: flex-start;
       }
 
       header h1 {
@@ -49,10 +51,21 @@
         font-weight: 600;
       }
 
+      header nav {
+        margin-left: auto;
+      }
+
       header nav a {
-        margin-left: 1rem;
+        margin-right: 1rem;
         color: var(--text);
         text-decoration: none;
+        font-size: 1.125rem;
+        font-weight: 600;
+        transition: color 0.2s;
+      }
+
+      header nav a:hover {
+        color: var(--nav-link-hover);
       }
 
       #theme-toggle {
@@ -98,7 +111,7 @@
   <body>
     <header>
       <h1><a href="/">Sidebar AI Chat</a></h1>
-      <nav><a href="/docs/">Documentation</a></nav>
+      <nav><a href="/docs/">Docs</a></nav>
       <button id="theme-toggle" aria-label="Toggle theme"></button>
     </header>
     <main>
@@ -113,7 +126,7 @@
       <p>If issues persist, reach out on the project repository with details.</p>
     </main>
     <footer>
-      © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Documentation</a>
+      © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Docs</a>
     </footer>
     <script>
       const year = document.getElementById("year");

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
         --status-bg: #fef3c7;
         --status-border: #fcd34d;
         --status-text: #92400e;
+        --nav-link-hover: #1f2937;
       }
 
       body {
@@ -54,6 +55,7 @@
         --status-bg: #78350f;
         --status-border: #f59e0b;
         --status-text: #fef3c7;
+        --nav-link-hover: #d1d5db;
       }
 
       header {
@@ -62,7 +64,7 @@
         padding: 1.5rem;
         display: flex;
         align-items: center;
-        justify-content: space-between;
+        justify-content: flex-start;
       }
 
       header h1 {
@@ -71,10 +73,21 @@
         font-weight: 600;
       }
 
+      header nav {
+        margin-left: auto;
+      }
+
       header nav a {
-        margin-left: 1rem;
+        margin-right: 1rem;
         color: var(--text);
         text-decoration: none;
+        font-size: 1.125rem;
+        font-weight: 600;
+        transition: color 0.2s;
+      }
+
+      header nav a:hover {
+        color: var(--nav-link-hover);
       }
 
       #theme-toggle {
@@ -154,7 +167,7 @@
   <body>
     <header>
       <h1><a href="/">Sidebar AI Chat</a></h1>
-      <nav><a href="/docs/">Documentation</a></nav>
+      <nav><a href="/docs/">Docs</a></nav>
       <button id="theme-toggle" aria-label="Toggle dark mode"></button>
     </header>
     <main>
@@ -244,7 +257,7 @@
         🚧 This project is still in development. Stay tuned for updates!
       </section>
     </main>
-    <footer>© <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Documentation</a></footer>
+    <footer>© <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Docs</a></footer>
 
     <script>
       const year = document.getElementById("year");


### PR DESCRIPTION
## Summary
- Push top navigation to the right for clearer layout
- Rename "Documentation" links and references to "Docs"
- Style "Docs" nav link to be semibold, larger, and darken on hover

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0f1c4118832dafc8366a048794f9