### PR TITLE
Style header title link

### DIFF
--- a/docs/faq.html
+++ b/docs/faq.html
@@ -51,6 +51,12 @@
         font-weight: 600;
       }
 
+      header h1 a,
+      header h1 a:visited {
+        color: #fff;
+        text-decoration: none;
+      }
+
       header nav {
         margin-left: auto;
       }

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -51,6 +51,12 @@
         font-weight: 600;
       }
 
+      header h1 a,
+      header h1 a:visited {
+        color: #fff;
+        text-decoration: none;
+      }
+
       header nav {
         margin-left: auto;
       }

--- a/docs/index.html
+++ b/docs/index.html
@@ -51,6 +51,12 @@
         font-weight: 600;
       }
 
+      header h1 a,
+      header h1 a:visited {
+        color: #fff;
+        text-decoration: none;
+      }
+
       header nav {
         margin-left: auto;
       }

--- a/docs/setup-instructions.html
+++ b/docs/setup-instructions.html
@@ -51,6 +51,12 @@
         font-weight: 600;
       }
 
+      header h1 a,
+      header h1 a:visited {
+        color: #fff;
+        text-decoration: none;
+      }
+
       header nav {
         margin-left: auto;
       }

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -51,6 +51,12 @@
         font-weight: 600;
       }
 
+      header h1 a,
+      header h1 a:visited {
+        color: #fff;
+        text-decoration: none;
+      }
+
       header nav {
         margin-left: auto;
       }

--- a/index.html
+++ b/index.html
@@ -73,6 +73,12 @@
         font-weight: 600;
       }
 
+      header h1 a,
+      header h1 a:visited {
+        color: #fff;
+        text-decoration: none;
+      }
+
       header nav {
         margin-left: auto;
       }


### PR DESCRIPTION
## Summary
- Remove underline from site title link in header and force white color
- Keep title link white after it's visited across all pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf139df710832d8890ab8bd8aa7e99