### PR TITLE
Rename setup instructions doc

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -26,7 +26,7 @@
       <h2>Docs</h2>
       <ul>
         <li><a href="getting-started.html">Getting Started</a></li>
-        <li><a href="setup-instructions.html">Setup Instructions</a></li>
+        <li><a href="setup-proxy-ollama-instructions.html">Setup Proxy Ollama Instructions</a></li>
         <li><a href="troubleshooting.html">Troubleshooting</a></li>
         <li><a href="faq.html">FAQ</a></li>
       </ul>

--- a/docs/setup-proxy-ollama-instructions.html
+++ b/docs/setup-proxy-ollama-instructions.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
-    <title>Setup Instructions - SidebarAIchat.com</title>
+    <title>Setup Proxy Ollama Instructions - SidebarAIchat.com</title>
     <link rel="stylesheet" href="/style.css">
   </head>
   <body>
@@ -20,11 +20,11 @@
       <ol>
         <li><a href="/">Home</a></li>
         <li><a href="/docs/">Docs</a></li>
-        <li><span aria-current="page">Setup Instructions</span></li>
+        <li><span aria-current="page">Setup Proxy Ollama Instructions</span></li>
       </ol>
     </nav>
     <main>
-      <h2>Setup Instructions</h2>
+      <h2>Setup Proxy Ollama Instructions</h2>
       <p>These steps walk you through connecting SidebarAI Chat to your own models and services.</p>
       <h3>1. Configure Ollama with a Reverse Proxy</h3>
       <p>Run Ollama behind a secure reverse proxy so it can be reached from your browser. Map the proxy to the port where Ollama listens and enable HTTPS.</p>

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
           Use your own API keys. Pick a model per chat. Keep everything local to your browser.
         </p>
         <p>
-          <a href="/docs/getting-started.html">Get Started</a> · <a href="/docs/setup-instructions.html">Setup</a> · <a href="/docs/troubleshooting.html">Troubleshooting</a>
+          <a href="/docs/getting-started.html">Get Started</a> · <a href="/docs/setup-proxy-ollama-instructions.html">Setup</a> · <a href="/docs/troubleshooting.html">Troubleshooting</a>
         </p>
         <img src="about:blank" alt="Sidebar AI Chat hero illustration" class="placeholder" />
       </section>


### PR DESCRIPTION
## Summary
- rename setup instructions page to setup-proxy-ollama-instructions
- update links to renamed page

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c058bf35c8832dbc5412891dcc8eb5