### PR TITLE
refactor: move inline scripts to external file

### DIFF
--- a/docs/faq.html
+++ b/docs/faq.html
@@ -32,28 +32,6 @@
     <footer>
       © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Docs</a>
     </footer>
-    <script>
-      const year = document.getElementById("year");
-      year.textContent = new Date().getFullYear();
-
-      const toggle = document.getElementById("theme-toggle");
-      const sunIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><path d="M12 1v2m0 18v2m11-11h-2M3 12H1m17.657-7.657l-1.414 1.414M6.343 17.657l-1.414 1.414m0-12.728l1.414 1.414m12.728 12.728l1.414-1.414"/></svg>';
-      const moonIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
-
-      function applyTheme(dark) {
-        document.body.classList.toggle("dark", dark);
-        toggle.innerHTML = dark ? sunIcon : moonIcon;
-        toggle.setAttribute("aria-label", dark ? "Switch to light mode" : "Switch to dark mode");
-      }
-
-      const stored = localStorage.getItem("theme");
-      applyTheme(stored ? stored === "dark" : window.matchMedia("(prefers-color-scheme: dark)").matches);
-
-      toggle.addEventListener("click", () => {
-        const isDark = !document.body.classList.contains("dark");
-        applyTheme(isDark);
-        localStorage.setItem("theme", isDark ? "dark" : "light");
-      });
-    </script>
+    <script src="/script.js"></script>
   </body>
 </html>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -34,28 +34,6 @@
     <footer>
       © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Docs</a>
     </footer>
-    <script>
-      const year = document.getElementById("year");
-      year.textContent = new Date().getFullYear();
-
-      const toggle = document.getElementById("theme-toggle");
-      const sunIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><path d="M12 1v2m0 18v2m11-11h-2M3 12H1m17.657-7.657l-1.414 1.414M6.343 17.657l-1.414 1.414m0-12.728l1.414 1.414m12.728 12.728l1.414-1.414"/></svg>';
-      const moonIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
-
-      function applyTheme(dark) {
-        document.body.classList.toggle("dark", dark);
-        toggle.innerHTML = dark ? sunIcon : moonIcon;
-        toggle.setAttribute("aria-label", dark ? "Switch to light mode" : "Switch to dark mode");
-      }
-
-      const stored = localStorage.getItem("theme");
-      applyTheme(stored ? stored === "dark" : window.matchMedia("(prefers-color-scheme: dark)").matches);
-
-      toggle.addEventListener("click", () => {
-        const isDark = !document.body.classList.contains("dark");
-        applyTheme(isDark);
-        localStorage.setItem("theme", isDark ? "dark" : "light");
-      });
-    </script>
+    <script src="/script.js"></script>
   </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -34,28 +34,6 @@
     <footer>
       © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Docs</a>
     </footer>
-    <script>
-      const year = document.getElementById("year");
-      year.textContent = new Date().getFullYear();
-
-      const toggle = document.getElementById("theme-toggle");
-      const sunIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><path d="M12 1v2m0 18v2m11-11h-2M3 12H1m17.657-7.657l-1.414 1.414M6.343 17.657l-1.414 1.414m0-12.728l1.414 1.414m12.728 12.728l1.414-1.414"/></svg>';
-      const moonIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
-
-      function applyTheme(dark) {
-        document.body.classList.toggle("dark", dark);
-        toggle.innerHTML = dark ? sunIcon : moonIcon;
-        toggle.setAttribute("aria-label", dark ? "Switch to light mode" : "Switch to dark mode");
-      }
-
-      const stored = localStorage.getItem("theme");
-      applyTheme(stored ? stored === "dark" : window.matchMedia("(prefers-color-scheme: dark)").matches);
-
-      toggle.addEventListener("click", () => {
-        const isDark = !document.body.classList.contains("dark");
-        applyTheme(isDark);
-        localStorage.setItem("theme", isDark ? "dark" : "light");
-      });
-    </script>
+    <script src="/script.js"></script>
   </body>
 </html>

--- a/docs/setup-proxy-ollama-instructions.html
+++ b/docs/setup-proxy-ollama-instructions.html
@@ -93,28 +93,6 @@ server {
     <footer>
       © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Docs</a>
     </footer>
-    <script>
-      const year = document.getElementById("year");
-      year.textContent = new Date().getFullYear();
-
-      const toggle = document.getElementById("theme-toggle");
-      const sunIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><path d="M12 1v2m0 18v2m11-11h-2M3 12H1m17.657-7.657l-1.414 1.414M6.343 17.657l-1.414 1.414m0-12.728l1.414 1.414m12.728 12.728l1.414-1.414"/></svg>';
-      const moonIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
-
-      function applyTheme(dark) {
-        document.body.classList.toggle("dark", dark);
-        toggle.innerHTML = dark ? sunIcon : moonIcon;
-        toggle.setAttribute("aria-label", dark ? "Switch to light mode" : "Switch to dark mode");
-      }
-
-      const stored = localStorage.getItem("theme");
-      applyTheme(stored ? stored === "dark" : window.matchMedia("(prefers-color-scheme: dark)").matches);
-
-      toggle.addEventListener("click", () => {
-        const isDark = !document.body.classList.contains("dark");
-        applyTheme(isDark);
-        localStorage.setItem("theme", isDark ? "dark" : "light");
-      });
-    </script>
+    <script src="/script.js"></script>
   </body>
 </html>

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -37,28 +37,6 @@
     <footer>
       © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Docs</a>
     </footer>
-    <script>
-      const year = document.getElementById("year");
-      year.textContent = new Date().getFullYear();
-
-      const toggle = document.getElementById("theme-toggle");
-      const sunIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><path d="M12 1v2m0 18v2m11-11h-2M3 12H1m17.657-7.657l-1.414 1.414M6.343 17.657l-1.414 1.414m0-12.728l1.414 1.414m12.728 12.728l1.414-1.414"/></svg>';
-      const moonIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
-
-      function applyTheme(dark) {
-        document.body.classList.toggle("dark", dark);
-        toggle.innerHTML = dark ? sunIcon : moonIcon;
-        toggle.setAttribute("aria-label", dark ? "Switch to light mode" : "Switch to dark mode");
-      }
-
-      const stored = localStorage.getItem("theme");
-      applyTheme(stored ? stored === "dark" : window.matchMedia("(prefers-color-scheme: dark)").matches);
-
-      toggle.addEventListener("click", () => {
-        const isDark = !document.body.classList.contains("dark");
-        applyTheme(isDark);
-        localStorage.setItem("theme", isDark ? "dark" : "light");
-      });
-    </script>
+    <script src="/script.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -104,37 +104,6 @@
     </main>
     <footer>© <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Docs</a></footer>
 
-    <script>
-      const year = document.getElementById("year");
-      year.textContent = new Date().getFullYear();
-
-      const toggle = document.getElementById("theme-toggle");
-      const sunIcon =
-        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><path d="M12 1v2m0 18v2m11-11h-2M3 12H1m17.657-7.657l-1.414 1.414M6.343 17.657l-1.414 1.414m0-12.728l1.414 1.414m12.728 12.728l1.414-1.414"/></svg>';
-      const moonIcon =
-        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
-
-      function applyTheme(dark) {
-        document.body.classList.toggle("dark", dark);
-        toggle.innerHTML = dark ? sunIcon : moonIcon;
-        toggle.setAttribute(
-          "aria-label",
-          dark ? "Switch to light mode" : "Switch to dark mode",
-        );
-      }
-
-      const stored = localStorage.getItem("theme");
-      applyTheme(
-        stored
-          ? stored === "dark"
-          : window.matchMedia("(prefers-color-scheme: dark)").matches,
-      );
-
-      toggle.addEventListener("click", () => {
-        const isDark = !document.body.classList.contains("dark");
-        applyTheme(isDark);
-        localStorage.setItem("theme", isDark ? "dark" : "light");
-      });
-    </script>
+    <script src="/script.js"></script>
   </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,25 @@
+const year = document.getElementById("year");
+if (year) {
+  year.textContent = new Date().getFullYear();
+}
+
+const toggle = document.getElementById("theme-toggle");
+if (toggle) {
+  const sunIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><path d="M12 1v2m0 18v2m11-11h-2M3 12H1m17.657-7.657l-1.414 1.414M6.343 17.657l-1.414 1.414m0-12.728l1.414 1.414m12.728 12.728l1.414-1.414"/></svg>';
+  const moonIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+
+  function applyTheme(dark) {
+    document.body.classList.toggle("dark", dark);
+    toggle.innerHTML = dark ? sunIcon : moonIcon;
+    toggle.setAttribute("aria-label", dark ? "Switch to light mode" : "Switch to dark mode");
+  }
+
+  const stored = localStorage.getItem("theme");
+  applyTheme(stored ? stored === "dark" : window.matchMedia("(prefers-color-scheme: dark)").matches);
+
+  toggle.addEventListener("click", () => {
+    const isDark = !document.body.classList.contains("dark");
+    applyTheme(isDark);
+    localStorage.setItem("theme", isDark ? "dark" : "light");
+  });
+}


### PR DESCRIPTION
## Summary
- add shared `script.js` for year and theme toggle logic
- replace inline scripts with references to external file across site

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c05c40eb28832d9843746cbca23901