### PR TITLE
Add meta descriptions to docs pages

### DIFF
--- a/docs/faq.html
+++ b/docs/faq.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
+    <meta name="description" content="Answers to common questions about Sidebar AI Chat, including providers, storage, and costs." />
+    <link rel="icon" type="image/svg+xml" href="/chat.svg" />
     <title>FAQ - SidebarAIchat.com</title>
     <link rel="stylesheet" href="/style.css">
   </head>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
+    <meta name="description" content="Quick steps to install and configure Sidebar AI Chat with your own API keys." />
+    <link rel="icon" type="image/svg+xml" href="/chat.svg" />
     <title>Getting Started - SidebarAIchat.com</title>
     <link rel="stylesheet" href="/style.css">
   </head>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
+    <meta name="description" content="Documentation for Sidebar AI Chat, including setup guides, troubleshooting tips, and FAQs." />
+    <link rel="icon" type="image/svg+xml" href="/chat.svg" />
     <title>Docs - SidebarAIchat.com</title>
     <link rel="stylesheet" href="/style.css">
   </head>

--- a/docs/setup-proxy-ollama-instructions.html
+++ b/docs/setup-proxy-ollama-instructions.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
+    <meta name="description" content="How to configure a reverse proxy so Sidebar AI Chat can connect to Ollama models securely." />
+    <link rel="icon" type="image/svg+xml" href="/chat.svg" />
     <title>Set up Reverse Proxy for Ollama</title>
     <link rel="stylesheet" href="/style.css">
   </head>

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
+    <meta name="description" content="Solutions to common problems when using the Sidebar AI Chat browser extension." />
+    <link rel="icon" type="image/svg+xml" href="/chat.svg" />
     <title>Troubleshooting - SidebarAIchat.com</title>
     <link rel="stylesheet" href="/style.css">
   </head>


### PR DESCRIPTION
## Summary
- add meta description and favicon link tags to documentation HTML pages for better SEO

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c05df703ac832d9b101eb3376cd72b