### PR TITLE
feat: highlight proxy setup code

### DIFF
--- a/docs/setup-proxy-ollama-instructions.html
+++ b/docs/setup-proxy-ollama-instructions.html
@@ -8,6 +8,7 @@
     <link rel="icon" type="image/svg+xml" href="/chat.svg" />
     <title>Set up Reverse Proxy for Ollama</title>
     <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/vs2015.min.css">
   </head>
   <body>
     <header>
@@ -95,6 +96,8 @@ server {
     <footer>
       © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Docs</a>
     </footer>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+    <script>hljs.highlightAll();</script>
     <script src="/script.js"></script>
   </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -238,3 +238,10 @@
     background: #999999 !important;
     color: #dddddd !important;
   }
+
+  pre code {
+    display: block;
+    padding: 1rem;
+    border-radius: 6px;
+    overflow-x: auto;
+  }


### PR DESCRIPTION
## Summary
- highlight reverse proxy setup instructions with a syntax-highlighted code block
- style code blocks for readability

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c05f420110832d9f38fd5753c044ac