### PR TITLE
Add Nginx setup article and link from proxy instructions

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -28,6 +28,7 @@
       <h2>Docs</h2>
       <ul>
         <li><a href="getting-started.html">Getting Started</a></li>
+        <li><a href="setup-nginx.html">Set up Nginx</a></li>
         <li><a href="setup-proxy-ollama-instructions.html">Setup Proxy Ollama Instructions</a></li>
         <li><a href="troubleshooting.html">Troubleshooting</a></li>
         <li><a href="faq.html">FAQ</a></li>

--- a/docs/setup-nginx.html
+++ b/docs/setup-nginx.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
+    <meta name="description" content="Install Nginx on Windows, Linux, and macOS to serve as a reverse proxy or web server." />
+    <link rel="icon" type="image/svg+xml" href="/chat.svg" />
+    <title>Set up Nginx - SidebarAIchat.com</title>
+    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/vs2015.min.css">
+  </head>
+  <body>
+    <header>
+      <h1><a href="/"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="white" class="header-icon">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M8.625 12a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H8.25m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H12m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 0 1-2.555-.337A5.972 5.972 0 0 1 5.41 20.97a5.969 5.969 0 0 1-.474-.065 4.48 4.48 0 0 0 .978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25Z" />
+      </svg>
+       Sidebar AI Chat</a></h1>
+      <nav><a href="/docs/">Docs</a></nav>
+      <button id="theme-toggle" aria-label="Toggle theme"></button>
+    </header>
+    <nav class="breadcrumbs" aria-label="Breadcrumb">
+      <ol>
+        <li><a href="/">Home</a></li>
+        <li><a href="/docs/">Docs</a></li>
+        <li><span aria-current="page">Set up Nginx</span></li>
+      </ol>
+    </nav>
+    <main>
+      <h2>Set up Nginx on Windows, Linux, and macOS</h2>
+      <p>Nginx is a high‑performance web server and reverse proxy. Follow these platform‑specific instructions to install it.</p>
+      <h3>Windows</h3>
+      <ol>
+        <li>Download the <a href="https://nginx.org/en/download.html">Windows build of Nginx</a>.</li>
+        <li>Extract the archive and run <code>nginx.exe</code>.</li>
+        <li>To start automatically, create a scheduled task or service pointing to the executable.</li>
+      </ol>
+      <h3>Linux</h3>
+      <p>Use your distribution's package manager:</p>
+      <pre><code class="hljs"># Debian/Ubuntu
+sudo apt update
+sudo apt install nginx
+
+# Fedora/CentOS/RHEL
+sudo dnf install nginx
+sudo systemctl enable --now nginx</code></pre>
+      <h3>macOS</h3>
+      <ol>
+        <li>Install <a href="https://brew.sh/">Homebrew</a> if you don't have it.</li>
+        <li>Run <code class="hljs">brew install nginx</code> to install.</li>
+        <li>Start Nginx with <code class="hljs">brew services start nginx</code> to run it in the background.</li>
+      </ol>
+      <p>Once Nginx is running, you can configure it as a reverse proxy or web server.</p>
+    </main>
+    <footer>
+      © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Docs</a>
+    </footer>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+    <script>hljs.highlightAll();</script>
+    <script src="/script.js"></script>
+  </body>
+</html>

--- a/docs/setup-proxy-ollama-instructions.html
+++ b/docs/setup-proxy-ollama-instructions.html
@@ -32,6 +32,7 @@
       <h3>1. Configure Ollama with a Reverse Proxy</h3>
       <p>Run Ollama behind a secure reverse proxy so it can be reached from your browser. Map the proxy to the port where Ollama listens and enable HTTPS.</p>
       <p>Ollama enforces a strict CORS policy and rejects unknown origins. Requests from the Chrome extension include a <code>chrome-extension://</code> origin that Ollama blocks, so the proxy must handle CORS headers.</p>
+      <p>If you need to install Nginx, see <a href="setup-nginx.html">Set up Nginx on Windows, Linux, and macOS</a>.</p>
       <pre><code class="hljs"># /etc/nginx/conf.d/ollama-proxy.conf
 
 # 1) Only allow CORS if Origin is exactly your extension.


### PR DESCRIPTION
## Summary
- Add guide for installing Nginx on Windows, Linux, and macOS
- Link to Nginx setup from the reverse proxy instructions
- Include the new guide in the docs index

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c06410fbb8832d9c54b04484fa98e2