### PR TITLE
Add standalone 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <link rel="icon" type="image/svg+xml" href="/chat.svg" />
+    <link rel="stylesheet" href="/style.css">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
+    <title>404 - Sidebar AI Chat</title>
+  </head>
+  <body>
+    <header>
+      <h1><a href="/"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="white" class="header-icon">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M8.625 12a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H8.25m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H12m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 0 1-2.555-.337A5.972 5.972 0 0 1 5.41 20.97a5.969 5.969 0 0 1-.474-.065 4.48 4.48 0 0 0 .978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25Z" />
+      </svg>
+       Sidebar AI Chat</a></h1>
+      <nav><a href="/docs/">Docs</a></nav>
+      <button id="theme-toggle" aria-label="Toggle dark mode"></button>
+    </header>
+    <main>
+      <section class="hero">
+        <h1>404 Page not found</h1>
+        <p class="text-center"><a href="/">Return to homepage</a></p>
+      </section>
+    </main>
+    <footer>© <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Docs</a></footer>
+
+    <script src="/script.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone 404 page with existing site styles

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c067b30cb8832da9e49137cfcd907d