### PR TITLE
Add robots.txt for search engines

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+# robots.txt for SidebarAI Chat
+User-agent: *
+Allow: /
+Disallow: /404.html


### PR DESCRIPTION
## Summary
- add `robots.txt` allowing crawlers to index site while excluding the custom 404 page

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c06f36c72c832dbd95c1b5957db92a