### PR TITLE
style: unify link colors with theme

### DIFF
--- a/style.css
+++ b/style.css
@@ -40,6 +40,12 @@
     --nav-link-hover: #d1d5db;
   }
 
+  a,
+  a:visited {
+    color: var(--text);
+    text-decoration-color: currentColor;
+  }
+
   header {
     background-color: var(--header-bg);
     border-bottom: 1px solid var(--border);


### PR DESCRIPTION
## Summary
- Use theme text color for standard links in both light and dark modes
- Ensure link underline matches text color

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c084e0a90c832d9cb0439463f46748