### PR TITLE
Fix header layout responsiveness across pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -9,12 +9,12 @@
     <title>404 - Sidebar AI Chat</title>
   </head>
   <body>
-    <header>
-      <h1><a href="/"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="header-icon">
+    <header class="site-header">
+      <h1 class="brand"><a href="/"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="header-icon">
         <path stroke-linecap="round" stroke-linejoin="round" d="M8.625 12a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H8.25m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H12m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 0 1-2.555-.337A5.972 5.972 0 0 1 5.41 20.97a5.969 5.969 0 0 1-.474-.065 4.48 4.48 0 0 0 .978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25Z" />
       </svg>
        Sidebar AI Chat</a></h1>
-      <nav><a href="/docs/">Docs</a></nav>
+      <nav class="site-nav"><a href="/docs/">Docs</a></nav>
       <button id="theme-toggle" aria-label="Toggle dark mode"></button>
     </header>
     <main>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -10,12 +10,12 @@
     <link rel="stylesheet" href="/style.css">
   </head>
   <body>
-    <header>
-      <h1><a href="/"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="header-icon">
+    <header class="site-header">
+      <h1 class="brand"><a href="/"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="header-icon">
         <path stroke-linecap="round" stroke-linejoin="round" d="M8.625 12a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H8.25m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H12m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 0 1-2.555-.337A5.972 5.972 0 0 1 5.41 20.97a5.969 5.969 0 0 1-.474-.065 4.48 4.48 0 0 0 .978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25Z" />
       </svg>
        Sidebar AI Chat</a></h1>
-      <nav><a href="/docs/">Docs</a></nav>
+      <nav class="site-nav"><a href="/docs/" aria-current="page">Docs</a></nav>
       <button id="theme-toggle" aria-label="Toggle theme"></button>
     </header>
     <nav class="breadcrumbs" aria-label="Breadcrumb">

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -10,12 +10,12 @@
     <link rel="stylesheet" href="/style.css">
   </head>
   <body>
-    <header>
-      <h1><a href="/"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="header-icon">
+    <header class="site-header">
+      <h1 class="brand"><a href="/"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="header-icon">
         <path stroke-linecap="round" stroke-linejoin="round" d="M8.625 12a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H8.25m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H12m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 0 1-2.555-.337A5.972 5.972 0 0 1 5.41 20.97a5.969 5.969 0 0 1-.474-.065 4.48 4.48 0 0 0 .978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25Z" />
       </svg>
        Sidebar AI Chat</a></h1>
-      <nav><a href="/docs/">Docs</a></nav>
+      <nav class="site-nav"><a href="/docs/" aria-current="page">Docs</a></nav>
       <button id="theme-toggle" aria-label="Toggle theme"></button>
     </header>
     <nav class="breadcrumbs" aria-label="Breadcrumb">

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,12 +10,12 @@
     <link rel="stylesheet" href="/style.css">
   </head>
   <body>
-    <header>
-      <h1><a href="/"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="header-icon">
+    <header class="site-header">
+      <h1 class="brand"><a href="/"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="header-icon">
         <path stroke-linecap="round" stroke-linejoin="round" d="M8.625 12a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H8.25m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H12m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 0 1-2.555-.337A5.972 5.972 0 0 1 5.41 20.97a5.969 5.969 0 0 1-.474-.065 4.48 4.48 0 0 0 .978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25Z" />
       </svg>
        Sidebar AI Chat</a></h1>
-      <nav><a href="/docs/">Docs</a></nav>
+      <nav class="site-nav"><a href="/docs/" aria-current="page">Docs</a></nav>
       <button id="theme-toggle" aria-label="Toggle theme"></button>
     </header>
     <nav class="breadcrumbs" aria-label="Breadcrumb">

--- a/docs/setup-nginx.html
+++ b/docs/setup-nginx.html
@@ -11,12 +11,12 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/vs2015.min.css">
   </head>
   <body>
-    <header>
-      <h1><a href="/"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="header-icon">
+    <header class="site-header">
+      <h1 class="brand"><a href="/"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="header-icon">
         <path stroke-linecap="round" stroke-linejoin="round" d="M8.625 12a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H8.25m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H12m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 0 1-2.555-.337A5.972 5.972 0 0 1 5.41 20.97a5.969 5.969 0 0 1-.474-.065 4.48 4.48 0 0 0 .978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25Z" />
       </svg>
        Sidebar AI Chat</a></h1>
-      <nav><a href="/docs/">Docs</a></nav>
+      <nav class="site-nav"><a href="/docs/" aria-current="page">Docs</a></nav>
       <button id="theme-toggle" aria-label="Toggle theme"></button>
     </header>
     <nav class="breadcrumbs" aria-label="Breadcrumb">

--- a/docs/setup-proxy-ollama-instructions.html
+++ b/docs/setup-proxy-ollama-instructions.html
@@ -11,12 +11,12 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/vs2015.min.css">
   </head>
   <body>
-    <header>
-      <h1><a href="/"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="header-icon">
+    <header class="site-header">
+      <h1 class="brand"><a href="/"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="header-icon">
         <path stroke-linecap="round" stroke-linejoin="round" d="M8.625 12a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H8.25m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H12m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 0 1-2.555-.337A5.972 5.972 0 0 1 5.41 20.97a5.969 5.969 0 0 1-.474-.065 4.48 4.48 0 0 0 .978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25Z" />
       </svg>
        Sidebar AI Chat</a></h1>
-      <nav><a href="/docs/">Docs</a></nav>
+      <nav class="site-nav"><a href="/docs/" aria-current="page">Docs</a></nav>
       <button id="theme-toggle" aria-label="Toggle theme"></button>
     </header>
     <nav class="breadcrumbs" aria-label="Breadcrumb">

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -10,12 +10,12 @@
     <link rel="stylesheet" href="/style.css">
   </head>
   <body>
-    <header>
-      <h1><a href="/"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="header-icon">
+    <header class="site-header">
+      <h1 class="brand"><a href="/"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="header-icon">
         <path stroke-linecap="round" stroke-linejoin="round" d="M8.625 12a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H8.25m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H12m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 0 1-2.555-.337A5.972 5.972 0 0 1 5.41 20.97a5.969 5.969 0 0 1-.474-.065 4.48 4.48 0 0 0 .978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25Z" />
       </svg>
        Sidebar AI Chat</a></h1>
-      <nav><a href="/docs/">Docs</a></nav>
+      <nav class="site-nav"><a href="/docs/" aria-current="page">Docs</a></nav>
       <button id="theme-toggle" aria-label="Toggle theme"></button>
     </header>
     <nav class="breadcrumbs" aria-label="Breadcrumb">

--- a/style.css
+++ b/style.css
@@ -58,6 +58,7 @@ header {
   display: flex;
   align-items: center;
   justify-content: flex-start;
+  gap: 1.25rem;
 }
 
 .brand {
@@ -73,6 +74,25 @@ header h1 { margin: 0; font-size: 1.125rem; font-weight: 600; }
     }
   }
 
+@media (max-width: 600px) {
+  .site-header,
+  header {
+    padding: 1rem 1.25rem;
+    gap: 1rem;
+  }
+
+  .site-nav a,
+  header nav a {
+    margin-right: 0.75rem;
+    font-size: 0.95rem;
+  }
+
+  #theme-toggle {
+    width: 32px;
+    height: 32px;
+  }
+}
+
 .brand a,
 .brand a:visited,
 header h1 a,
@@ -86,6 +106,7 @@ header h1 a {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
+  white-space: nowrap;
 }
 
 .site-nav,
@@ -101,6 +122,16 @@ header nav a {
   font-size: 1rem;
   font-weight: 600;
   transition: color 0.2s;
+}
+
+.site-nav a[aria-current="page"],
+header nav a[aria-current="page"] {
+  color: var(--muted);
+}
+
+.site-nav a:last-child,
+header nav a:last-child {
+  margin-right: 0;
 }
 
 .site-nav a:hover,


### PR DESCRIPTION
## Summary
- align the 404 page and all documentation pages with the landing header markup so they reuse the shared site header styling
- mark the Docs navigation link as the current section on documentation pages for clearer context
- tweak header spacing and responsive styles so the brand and controls stay on a single row on smaller screens

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e40c671a54832dba840cd236682f83