### PR TITLE
Improve clarity across documentation pages

### DIFF
--- a/docs/faq.html
+++ b/docs/faq.html
@@ -27,9 +27,11 @@
     </nav>
     <main>
       <h2>FAQ</h2>
-      <p><strong>Can I use multiple AI providers?</strong><br />Yes. Add each provider in the settings and choose the one you need per chat.</p>
-      <p><strong>Where are my chats stored?</strong><br />Chats are saved locally in your browser. Clearing your cache will remove them.</p>
-      <p><strong>Is there a cost to use SidebarAI Chat?</strong><br />The extension is free. You only pay for usage from your API provider.</p>
+      <p><strong>Can I use multiple AI providers?</strong><br />Yes. Add each provider in the settings and choose the one you need for every chat. You can switch models without losing conversation history.</p>
+      <p><strong>Where are my chats stored?</strong><br />Chats are saved locally in your browser. Clearing your cache or uninstalling the extension removes them, so export important conversations first.</p>
+      <p><strong>Is there a cost to use SidebarAI Chat?</strong><br />The extension is free. You only pay for usage charged by the API providers whose keys you connect.</p>
+      <p><strong>Does Sidebar AI Chat send data to external servers?</strong><br />No. Requests go directly from your browser to the provider or proxy you configure. Ensure HTTPS is enabled on any proxy you expose to the public internet.</p>
+      <p><strong>How do I find the extension ID mentioned in the proxy guide?</strong><br />Open <strong>chrome://extensions</strong>, enable developer mode, and copy the ID shown under Sidebar AI Chat.</p>
     </main>
     <footer>
       © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Docs</a>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -27,11 +27,14 @@
     </nav>
     <main>
       <h2>Getting Started</h2>
-      <p>SidebarAI Chat lets you bring any AI model into your browser without subscriptions.</p>
-      <p>1. Install the extension and open the sidebar.
-      <br>2. Add your preferred AI model provider.
-      <br>3. Start a new chat and plug in your API key when prompted.</p>
-      <p>You're ready to begin chatting with your chosen model.</p>
+      <p>Follow these steps to move from installation to your first successful conversation.</p>
+      <h3>1. Install and open the extension</h3>
+      <p>Install Sidebar AI Chat from the Chrome Web Store (when available) or load the unpacked extension in developer mode. Once installed, open the browser side panel and choose <em>Sidebar AI Chat</em> from the list of panels.</p>
+      <h3>2. Add a provider</h3>
+      <p>In the extension settings, pick <strong>Providers &gt; Add provider</strong>. Choose the model provider you want to use (for example OpenAI or Ollama) and paste in the API key or base URL it requires.</p>
+      <h3>3. Start your first chat</h3>
+      <p>Create a new chat, select the provider you just added, and enter your prompt. The extension stores conversations locally, so you can return to them later.</p>
+      <p>You can now repeat the process for additional providers or configure advanced settings like custom system prompts.</p>
     </main>
     <footer>
       © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Docs</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -26,12 +26,13 @@
     </nav>
     <main>
       <h2>Docs</h2>
+      <p>Use the guides below to install the extension, connect to models, and keep things running smoothly.</p>
       <ul>
-        <li><a href="getting-started.html">Getting Started</a></li>
-        <li><a href="setup-nginx.html">Set up Nginx</a></li>
-        <li><a href="setup-proxy-ollama-instructions.html">Setup Proxy Ollama Instructions</a></li>
-        <li><a href="troubleshooting.html">Troubleshooting</a></li>
-        <li><a href="faq.html">FAQ</a></li>
+        <li><a href="getting-started.html">Getting Started</a> – install the extension, add providers, and launch your first chat.</li>
+        <li><a href="setup-nginx.html">Set up Nginx</a> – install Nginx on Windows, Linux, or macOS so you can proxy requests securely.</li>
+        <li><a href="setup-proxy-ollama-instructions.html">Set up Reverse Proxy for Ollama</a> – configure headers and routing so Sidebar AI Chat can reach Ollama.</li>
+        <li><a href="troubleshooting.html">Troubleshooting</a> – fix the most common connection and configuration issues.</li>
+        <li><a href="faq.html">FAQ</a> – quick answers about storage, pricing, and provider support.</li>
       </ul>
     </main>
     <footer>

--- a/docs/setup-nginx.html
+++ b/docs/setup-nginx.html
@@ -28,12 +28,12 @@
     </nav>
     <main>
       <h2>Set up Nginx on Windows, Linux, and macOS</h2>
-      <p>Nginx is a high‑performance web server and reverse proxy. Follow these platform‑specific instructions to install it.</p>
+      <p>Nginx is a high-performance web server and reverse proxy. Install it on the platform you use to host Sidebar AI Chat integrations.</p>
       <h3>Windows</h3>
       <ol>
         <li>Download the <a href="https://nginx.org/en/download.html">Windows build of Nginx</a>.</li>
-        <li>Extract the archive and run <code>nginx.exe</code>.</li>
-        <li>To start automatically, create a scheduled task or service pointing to the executable.</li>
+        <li>Extract the archive to a permanent folder such as <code>C:\nginx</code> and run <code>nginx.exe</code>.</li>
+        <li>To start automatically, create a scheduled task or Windows service that launches the executable on boot.</li>
       </ol>
       <h3>Linux</h3>
       <p>Use your distribution's package manager:</p>
@@ -44,13 +44,15 @@ sudo apt install nginx
 # Fedora/CentOS/RHEL
 sudo dnf install nginx
 sudo systemctl enable --now nginx</code></pre>
+      <p>After installation, ensure the service is running with <code>systemctl status nginx</code>.</p>
       <h3>macOS</h3>
       <ol>
         <li>Install <a href="https://brew.sh/">Homebrew</a> if you don't have it.</li>
-        <li>Run <code class="hljs">brew install nginx</code> to install.</li>
-        <li>Start Nginx with <code class="hljs">brew services start nginx</code> to run it in the background.</li>
+        <li>Run <code class="hljs">brew install nginx</code>.</li>
+        <li>Start Nginx in the background with <code class="hljs">brew services start nginx</code>.</li>
       </ol>
-      <p>Once Nginx is running, you can configure it as a reverse proxy or web server.</p>
+      <h3>Next steps</h3>
+      <p>Once Nginx is running, update the configuration file for your proxy. Replace the <code>chrome-extension://ID</code> placeholder with your actual extension ID, then reload Nginx (<code>nginx -s reload</code> or <code>systemctl reload nginx</code>) so the changes take effect.</p>
     </main>
     <footer>
       © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Docs</a>

--- a/docs/setup-proxy-ollama-instructions.html
+++ b/docs/setup-proxy-ollama-instructions.html
@@ -83,10 +83,6 @@
         }
     }
     </code></pre>
-      <p>Replace <code>ID</code> with the actual extension ID from <strong>chrome://extensions</strong>. If you serve Sidebar AI Chat from a custom domain, include that domain in an additional <code>add_header 'Access-Control-Allow-Origin'</code> line.</p>
-      <h3>2. Provide API keys</h3>
-      <p>Create or obtain API keys from your chosen model providers. In the extension's settings, add each key under the appropriate provider.</p>
-      <h3>3. Verify connectivity</h3>
       <p>Reload Nginx, open the sidebar, and start a test chat. You should see a streaming response from the model. If the request fails, inspect the browser console and Nginx logs for CORS or proxy errors.</p>
     </main>
     <footer>

--- a/docs/setup-proxy-ollama-instructions.html
+++ b/docs/setup-proxy-ollama-instructions.html
@@ -28,12 +28,12 @@
     </nav>
     <main>
       <h2>Set up Reverse Proxy for Ollama</h2>
-      <p>These steps walk you through connecting SidebarAI Chat to your own models and services.</p>
-      <h3>1. Configure Ollama with a Reverse Proxy</h3>
-      <p>Run Ollama behind a secure reverse proxy so it can be reached from your browser. Map the proxy to the port where Ollama listens and enable HTTPS.</p>
-      <p>Ollama enforces a strict CORS policy and rejects unknown origins. Requests from the Chrome extension include a <code>chrome-extension://</code> origin that Ollama blocks, so the proxy must handle CORS headers.</p>
-      <p>If you need to install Nginx, see <a href="setup-nginx.html">Set up Nginx on Windows, Linux, and macOS</a>.</p>
-      <p><strong>Create new file </strong> 
+      <p>Follow these steps to expose Ollama through a secure proxy that speaks the headers Sidebar AI Chat expects.</p>
+      <h3>1. Configure Ollama behind a reverse proxy</h3>
+      <p>Run Ollama on a host you control and place a reverse proxy (Nginx or similar) in front of it. Point the proxy at the port where Ollama listens, require HTTPS for external traffic, and restrict access to trusted networks.</p>
+      <p>Ollama enforces a strict CORS policy and rejects unknown origins. Requests from the Chrome extension include a <code>chrome-extension://</code> origin that Ollama blocks, so the proxy must add CORS headers for that ID.</p>
+      <p>If you need to install Nginx first, see <a href="setup-nginx.html">Set up Nginx on Windows, Linux, and macOS</a>.</p>
+      <p><strong>Create new file </strong>
         <code class="command" id="nginx-default-path">(detecting OS...)</code></p>
       <div class="code-toolbar">
         <button type="button" class="code-toggle" id="code-toggle" aria-pressed="true" data-code="nginx-proxy">Hide code</button>
@@ -42,9 +42,9 @@
       <pre data-code="nginx-proxy"><code class="hljs language-python">server {
         listen 8080;
         server_name localhost;
-    
+
         client_max_body_size 100M;
-    
+
         location / {
             if ($request_method = 'OPTIONS') {
                 add_header 'Access-Control-Allow-Origin' 'chrome-extension://ID';
@@ -55,27 +55,27 @@
                 add_header 'Content-Length' 0;
                 return 204;
             }
-    
+
             # CORS headers for actual requests
             add_header 'Access-Control-Allow-Origin' 'chrome-extension://ID' always;
             add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT, DELETE' always;
             add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization' always;
             add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
-    
+
             # Proxy to Ollama
             proxy_pass http://127.0.0.1:11434;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-    
+
             # Remove/override Origin header to prevent leakage
             proxy_set_header Origin "";
-    
+
             # Handle streaming responses
             proxy_buffering off;
             proxy_cache off;
-    
+
             # Increase timeouts for long-running requests
             proxy_connect_timeout 60s;
             proxy_send_timeout 300s;
@@ -83,10 +83,11 @@
         }
     }
     </code></pre>
-      <h3>2. Provide API Keys</h3>
+      <p>Replace <code>ID</code> with the actual extension ID from <strong>chrome://extensions</strong>. If you serve Sidebar AI Chat from a custom domain, include that domain in an additional <code>add_header 'Access-Control-Allow-Origin'</code> line.</p>
+      <h3>2. Provide API keys</h3>
       <p>Create or obtain API keys from your chosen model providers. In the extension's settings, add each key under the appropriate provider.</p>
-      <h3>3. Verify Connectivity</h3>
-      <p>Open the sidebar and start a test chat. If the model responds, your setup is complete.</p>
+      <h3>3. Verify connectivity</h3>
+      <p>Reload Nginx, open the sidebar, and start a test chat. You should see a streaming response from the model. If the request fails, inspect the browser console and Nginx logs for CORS or proxy errors.</p>
     </main>
     <footer>
       © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Docs</a>

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -27,14 +27,26 @@
     </nav>
     <main>
       <h2>Troubleshooting</h2>
-      <p>If something isn't working, try the following steps:</p>
+      <p>If something is not working, work through the relevant section below.</p>
+      <h3>No responses from the model</h3>
       <ul>
-        <li>Refresh the page or restart your browser.</li>
-        <li>Verify that your API keys are valid and have not expired.</li>
-        <li>Check your network connection and proxy settings.</li>
-        <li>Look at the browser console for error messages.</li>
+        <li>Confirm your API key is correct and has quota remaining.</li>
+        <li>Check that your proxy or Ollama instance is reachable from the machine running your browser.</li>
+        <li>Open the browser developer tools (Console tab) to look for CORS or network errors.</li>
       </ul>
-      <p>If issues persist, reach out on the project repository with details.</p>
+      <h3>Extension does not load</h3>
+      <ul>
+        <li>Reload the side panel or restart the browser entirely.</li>
+        <li>Disable conflicting extensions that also customize the side panel.</li>
+        <li>If you are using an unpacked build, verify the source folder is still accessible on disk.</li>
+      </ul>
+      <h3>Proxy configuration issues</h3>
+      <ul>
+        <li>Review your Nginx (or other proxy) logs for denied requests.</li>
+        <li>Ensure the <code>chrome-extension://ID</code> placeholder was replaced with the real extension ID.</li>
+        <li>After editing the configuration, reload the proxy so the new settings apply.</li>
+      </ul>
+      <p>If issues persist, open an issue on the project repository with screenshots, console logs, and the steps to reproduce the problem.</p>
     </main>
     <footer>
       © <span id="year"></span> SidebarAIchat.com | <a href="/docs/">Docs</a>


### PR DESCRIPTION
## Summary
- expand the docs landing page with descriptions for each guide
- restructure the getting started, Nginx, and proxy instructions for clearer step-by-step guidance
- add more targeted troubleshooting and FAQ answers about storage, pricing, and extension IDs

## Testing
- not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68e410d0d580832dabca6c10a5728639